### PR TITLE
Add basic turret targeting options

### DIFF
--- a/scenes/maps/ruined_shrine.tscn
+++ b/scenes/maps/ruined_shrine.tscn
@@ -33,3 +33,15 @@ position = Vector2( 1109, 529 )
 
 [node name="Simple Turret" parent="." instance=ExtResource( 3 )]
 position = Vector2( 795, 431 )
+Cooldown = 50.0
+Damage = 5.0
+Targeting = 2
+
+[node name="Turret" parent="." instance=ExtResource( 3 )]
+position = Vector2( 641, 259 )
+Targeting = 2
+
+[node name="Turret2" parent="." instance=ExtResource( 3 )]
+position = Vector2( 848, 211 )
+Damage = 5.0
+Targeting = 5

--- a/src/Turret.cs
+++ b/src/Turret.cs
@@ -85,13 +85,13 @@ public class Turret : Node2D
 
     private void BodyEntered(Node body)
     {
-		if (body is not creep)
-			return;
+        if (body is not creep)
+            return;
 
-		var s = (creep)body;
+        var s = (creep)body;
 
-		Targets.Add(s);
-		UpdateTarget();
+        Targets.Add(s);
+        UpdateTarget();
     }
 
     private void BodyExited(Node body)
@@ -106,7 +106,7 @@ public class Turret : Node2D
 
 
         Targets.Remove(s);
-		UpdateTarget();
+        UpdateTarget();
     }
 
     private void UpdateTarget()

--- a/src/Turret.cs
+++ b/src/Turret.cs
@@ -11,12 +11,12 @@ public class Turret : Node2D
     [Flags]
     public enum TargetingType
     {
-        First = 0,
-        Last = 1,
-        Closest = 2,
-        Furthest = 3,
-        Strongest = 4,
-        Weakest = 5
+        First,
+        Last,
+        Closest,
+        Furthest,
+        Strongest,
+        Weakest
     }
 
     [Export] float Cooldown = 100;
@@ -26,8 +26,8 @@ public class Turret : Node2D
     creep? Target;
     DateTime LastFire = DateTime.Now;
 
-    [Export(PropertyHint.Enum, "First,Last,Closest,Furthest,Strongest,Weakest")]
-    public int Targeting = (int)TargetingType.First;
+    [Export(PropertyHint.Enum, nameof(TargetingType))]
+    public TargetingType Targeting = TargetingType.First;
 
     PackedScene ProjectileBase = ResourceLoader.Load<PackedScene>("res://scenes/entities/projectile.tscn");
 
@@ -60,17 +60,17 @@ public class Turret : Node2D
     {
         switch (Targeting)
         {
-            case (int)TargetingType.First:
+            case TargetingType.First:
                 return Targets.First();
-            case (int)TargetingType.Last:
+            case TargetingType.Last:
                 return Targets.Last();
-            case (int)TargetingType.Closest:
+            case TargetingType.Closest:
                 return Targets.OrderBy(x => Position.DistanceTo(x.Position)).First();
-            case (int)TargetingType.Furthest:
+            case TargetingType.Furthest:
                 return Targets.OrderBy(x => Position.DistanceTo(x.Position)).Last();
-            case (int)TargetingType.Strongest:
+            case TargetingType.Strongest:
                 return Targets.OrderBy(x => x.Health).Last();
-            case (int)TargetingType.Weakest:
+            case TargetingType.Weakest:
                 return Targets.OrderBy(x => x.Health).First();
             default:
                 throw new ArgumentOutOfRangeException($"Invalid Targeting Type: {Targeting}");

--- a/src/Turret.cs
+++ b/src/Turret.cs
@@ -8,80 +8,112 @@ using System.Reflection;
 
 public class Turret : Node2D
 {
-	[Export] float Cooldown = 10;
-	[Export] float Damage = 10;
-	
-	List<creep> Targets = new();
-	creep? Target;
-	DateTime LastFire = DateTime.Now;
+    [Flags]
+    public enum TargetingType
+    {
+        First = 0,
+        Last = 1,
+        Closest = 2,
+        Furthest = 3,
+        Strongest = 4,
+        Weakest = 5
+    }
 
-	PackedScene ProjectileBase = ResourceLoader.Load<PackedScene>("res://scenes/entities/projectile.tscn");
+    [Export] float Cooldown = 100;
+    [Export] float Damage = 10;
 
-	public override void _Ready()
-	{
-		var area = GetNode<Area2D>("Area2D");
+    List<creep> Targets = new();
+    creep? Target;
+    DateTime LastFire = DateTime.Now;
 
-		area.Connect("body_entered", this,"BodyEntered");
-		area.Connect("body_exited", this, "BodyExited");
-	}
+    [Export(PropertyHint.Enum, "First,Last,Closest,Furthest,Strongest,Weakest")]
+    public int Targeting = (int)TargetingType.First;
 
-	public override void _Process(float delta)
-	{
-		UpdateTarget();
-		
-		if (Target != null && LastFire.AddMilliseconds(Cooldown) < DateTime.Now)
-		{
-			LastFire = DateTime.Now;
-			var proj = ProjectileBase.Instance<projectile>();
-			proj.Speed = 600;
-			proj.Damage = Damage + (int)GD.RandRange(0, 10);
-			AddChild(proj);
-			proj.SetTarget(Target);
-		}
+    PackedScene ProjectileBase = ResourceLoader.Load<PackedScene>("res://scenes/entities/projectile.tscn");
 
-		Update();
-	}
+    public override void _Ready()
+    {
+        var area = GetNode<Area2D>("Area2D");
 
-	public override void _Draw()
-	{
-		if (Target != null)
-			DrawLine(new Vector2(0,0), Target.Position - Position, Color.Color8(255, 0, 0));	
-	}
+        area.Connect("body_entered", this, "BodyEntered");
+        area.Connect("body_exited", this, "BodyExited");
+    }
 
-	private void BodyEntered(Node body)
-	{
+    public override void _Process(float delta)
+    {
+        UpdateTarget();
+
+        if (Target != null && LastFire.AddMilliseconds(Cooldown) < DateTime.Now)
+        {
+            LastFire = DateTime.Now;
+            var proj = ProjectileBase.Instance<projectile>();
+            proj.Speed = 600;
+            proj.Damage = Damage + (int)GD.RandRange(0, 10);
+            AddChild(proj);
+            proj.SetTarget(Target);
+        }
+
+        Update();
+    }
+
+    private creep GetBestTargetFromTargetingType()
+    {
+        switch (Targeting)
+        {
+            case (int)TargetingType.First:
+                return Targets.First();
+            case (int)TargetingType.Last:
+                return Targets.Last();
+            case (int)TargetingType.Closest:
+                return Targets.OrderBy(x => Position.DistanceTo(x.Position)).First();
+            case (int)TargetingType.Furthest:
+                return Targets.OrderBy(x => Position.DistanceTo(x.Position)).Last();
+            case (int)TargetingType.Strongest:
+                return Targets.OrderBy(x => x.Health).Last();
+            case (int)TargetingType.Weakest:
+                return Targets.OrderBy(x => x.Health).First();
+            default:
+                throw new ArgumentOutOfRangeException($"Invalid Targeting Type: {Targeting}");
+        }
+    }
+
+    public override void _Draw()
+    {
+        if (Target != null)
+            DrawLine(new Vector2(0, 0), Target.Position - Position, Color.Color8(255, 0, 0));
+    }
+
+    private void BodyEntered(Node body)
+    {
 		if (body is not creep)
 			return;
-		
-		Targets.Add((creep)body);
-	}
-	
-	private void BodyExited(Node body)
-	{
-		if (body is not creep)
-			return;
-		
+
 		var s = (creep)body;
 
-		if (s == Target)
-			Target = null;
+		Targets.Add(s);
+		UpdateTarget();
+    }
+
+    private void BodyExited(Node body)
+    {
+        if (body is not creep)
+            return;
+
+        var s = (creep)body;
+
+        if (s == Target)
+            Target = null;
 
 
-		Targets.Remove(s);
-	}
+        Targets.Remove(s);
+		UpdateTarget();
+    }
 
-	private void UpdateTarget()
-	{
-		if (Targets.Count == 0)
-			return;
+    private void UpdateTarget()
+    {
+        if (Targets.Count == 0)
+            return;
 
-
-		var closestTarget = Targets.First();
-
-		foreach (var target in Targets)
-			if (Position.DistanceTo(target.Position) < Position.DistanceTo(closestTarget.Position))
-				closestTarget = target;
-
-		Target = closestTarget;
-	}
+        Target = GetBestTargetFromTargetingType();
+    }
 }

--- a/src/ruined_shrine.cs
+++ b/src/ruined_shrine.cs
@@ -4,7 +4,7 @@ using System;
 
 public class ruined_shrine : Node2D
 {
-	[Export] float SpawnRate = 1000;
+	[Export] float SpawnRate = 100;
 
 	DateTime LastSpawn = DateTime.Now;
 


### PR DESCRIPTION
Adds some very basic turret targeting types which closes #12 

There is no UI currently for switching the targeting type in game but that will surely be added in #6

![Godot_v3 5-stable_mono_win64_RbjAZxsdUP](https://user-images.githubusercontent.com/10362744/192411865-c8777786-c614-49e4-a732-79ee3015a6e5.gif)
